### PR TITLE
Fix multiple paragraph widgets added on every change

### DIFF
--- a/src/js/decorations/paragraph.js
+++ b/src/js/decorations/paragraph.js
@@ -1,13 +1,21 @@
 import createDeco from '../utils/create-deco';
 
+const par = 'par';
+
 export default (
   predicate = node => node.type === node.type.schema.nodes.paragraph
 ) => (from, to, doc, decos) => {
   let newDecos = decos;
   doc.nodesBetween(from, to, (node, pos) => {
-    newDecos = predicate(node)
-      ? newDecos.add(doc, [createDeco(pos + node.nodeSize - 1, 'par')])
-      : newDecos;
+    if (predicate(node)) {
+      const decoPos = pos + node.nodeSize - 1;
+      const oldDecos = newDecos.find(
+        decoPos,
+        decoPos,
+        spec => spec.key === par
+      );
+      newDecos = newDecos.remove(oldDecos).add(doc, [createDeco(decoPos, par)]);
+    }
   });
   return newDecos;
 };

--- a/src/js/utils/create-deco.js
+++ b/src/js/utils/create-deco.js
@@ -4,6 +4,7 @@ export default (pos, type) => {
   const span = document.createElement('span');
   span.classList.add('invisible', `invisible--${type}`);
   return Decoration.widget(pos, span, {
-    marks: []
+    marks: [],
+    key: type
   });
 };


### PR DESCRIPTION
@RichieAHB 
This is an attempt to fix a bug where on every change in a node's content a paragraph widget was added 
at the end without deleting the old one. This impacted performance and also looked weird after many changes were made inside one node.