### PR TITLE
Allow specifying invisible widget class in space builder predicate

### DIFF
--- a/src/js/decorations/character.js
+++ b/src/js/decorations/character.js
@@ -1,0 +1,15 @@
+import textBetween from '../utils/text-between';
+import createDeco from '../utils/create-deco';
+
+export default type => predicate => {
+  return (from, to, doc, decos) =>
+    textBetween(from, to, doc).reduce(
+      (decos1, { pos, text }) =>
+        text.split('').reduce((decos2, char, i) => {
+          return predicate(char)
+            ? decos2.add(doc, [createDeco(pos + i, type)])
+            : decos2;
+        }, decos1),
+      decos
+    );
+};

--- a/src/js/decorations/space.js
+++ b/src/js/decorations/space.js
@@ -1,19 +1,4 @@
-import textBetween from '../utils/text-between';
-import createDeco from '../utils/create-deco';
+import { default as character } from './character';
 
-export default (predicate = char => char === ' ') => {
-  return (from, to, doc, decos) =>
-    textBetween(from, to, doc).reduce(
-      (decos1, { pos, text }) =>
-        text
-          .split('')
-          .reduce(
-            (decos2, char, i) =>
-              predicate(char)
-                ? decos2.add(doc, [createDeco(pos + i, 'space')])
-                : decos2,
-            decos1
-          ),
-      decos
-    );
-};
+export default (predicate = char => char === ' ') =>
+  character('space')(predicate);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -30,6 +30,7 @@ export default builders => {
 };
 
 export { default as space } from './decorations/space';
+export { default as character } from './decorations/character';
 export { default as hardBreak } from './decorations/hard-break';
 export { default as paragraph } from './decorations/paragraph';
 


### PR DESCRIPTION
@RichieAHB 

This is done in order to allow the `space` builder to be used for other single-space invisible characters. For example non-breaking space, soft-hyphen etc.

Not really sure about the name of the function that the builder uses to determine the class of the invisible widget, since it's not really a predicate anymore.