### PR TITLE
Split `Element.classList.add` into 2 call to work in IE

### DIFF
--- a/src/js/utils/create-deco.js
+++ b/src/js/utils/create-deco.js
@@ -2,7 +2,8 @@ import { Decoration } from 'prosemirror-view';
 
 export default (pos, type) => {
   const span = document.createElement('span');
-  span.classList.add('invisible', `invisible--${type}`);
+  span.classList.add('invisible');
+  span.classList.add(`invisible--${type}`);
   return Decoration.widget(pos, span, {
     marks: [],
     key: type


### PR DESCRIPTION
This is to fix incompatibility with IE. It does not support multiple arguments for `Element.classList.add`:
https://developer.mozilla.org/en-US/docs/Web/API/Element/classList