### PR TITLE
Workaround caret positioning bug in Chrome

### DIFF
--- a/src/css/invisibles.scss
+++ b/src/css/invisibles.scss
@@ -1,6 +1,11 @@
 .invisible {
   pointer-events: none;
   user-select: none;
+  /* Chrome in particular dislikes doing the right thing
+   * with carets and inline elements when contenteditable
+   * is 'false'. See e.g. https://github.com/ProseMirror/prosemirror/issues/1061
+   */
+  display: inline-block;
 }
 
 .invisible:before {


### PR DESCRIPTION
## What does this change?

At the moment, certain cursor positions don't appear in Chrome. This is a known issue with that browser that we've bumped into a [couple](https://github.com/ProseMirror/prosemirror/issues/1061) of [times](https://github.com/ProseMirror/prosemirror/issues/942) and is tracked in [Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=977991&can=2&q=dom%20selection%20wrong%20offset).

Hard to show in a GIF, but here's a try:

![invisibles-caret](https://user-images.githubusercontent.com/7767575/103284527-5f41b180-49d3-11eb-88e0-088cfbcd6e19.gif)


## How to test

Have a click/arrow-key around into positions where invisibles appear, in Chrome (tested in 87.0.4280.88). You should find that, unlike before, the caret appears where it should.

## How can we measure success?

Users see carets when they click into positions that contain invisible characters.
