### PR TITLE
Defer widget decoration rendering

### DIFF
--- a/src/ts/utils/create-deco.ts
+++ b/src/ts/utils/create-deco.ts
@@ -1,10 +1,13 @@
 import { Decoration } from "prosemirror-view";
 
 export default (pos: number, type: string): Decoration => {
-  const span = document.createElement("span");
-  span.classList.add("invisible");
-  span.classList.add(`invisible--${type}`);
-  return Decoration.widget(pos, span, {
+  const createElement = () => {
+    const span = document.createElement("span");
+    span.classList.add("invisible");
+    span.classList.add(`invisible--${type}`);
+    return span;
+  }
+  return Decoration.widget(pos, createElement, {
     marks: [],
     key: type,
   });


### PR DESCRIPTION
NB: depends on #24 – please review that first!

## What does this change?

A minor change to defer widget decoration rendering, as the [docs suggest](https://prosemirror.net/docs/ref/#view.Decoration^widget).

## How to test

This is a no-op – everything should continue to work as before.
