### PR TITLE
Add declarations to ./dist build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.2",
   "description": "A plugin to show invisibles in prosemirror",
   "main": "dist/invisibles.js",
+  "types": "dist/index.d.ts",
   "license": "MIT",
   "author": {
     "name": "Richard Beddington",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/prosemirror-invisibles",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A plugin to show invisibles in prosemirror",
   "main": "dist/invisibles.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/prosemirror-invisibles",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A plugin to show invisibles in prosemirror",
   "main": "dist/invisibles.js",
   "types": "dist/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,11 @@ export default [
       eslint({
         exclude: ["node_modules/**"]
       }),
-      typescript()
+      typescript({
+        tsconfigOverride: {
+          compilerOptions: { declaration: true }
+        }
+      })
     ]
   },
   {


### PR DESCRIPTION
## What does this change?

At the moment, we're missing Typescript declarations in our build output. This PR adds them.

## How to test

Run `npm run build` in the project root. Can you see declaration files added to the `./dist` folder?

## How can we measure success?

Types are available when we import this project.