### PR TITLE
Layout amendments

### DIFF
--- a/src/css/invisibles.css
+++ b/src/css/invisibles.css
@@ -31,9 +31,12 @@
   content: "¶";
 }
 
+.invisible--nb-space {
+  vertical-align: text-bottom;
+}
+
 .invisible--nb-space:before {
   font-size: 15px;
-  vertical-align: bottom;
   content: "^";
   position: absolute;
   top: -6px;

--- a/src/ts/utils/create-deco.ts
+++ b/src/ts/utils/create-deco.ts
@@ -10,5 +10,6 @@ export default (pos: number, type: string): Decoration => {
   return Decoration.widget(pos, createElement, {
     marks: [],
     key: type,
+    side: 1000, // always render last
   });
 };


### PR DESCRIPTION
## What does this change?
Currently some layout and behaviour issues are not behaving consistently or how we would like.

- Fixes a bug where nb-space invisibles are positioned incorrectly in Firefox.

|Before|After|
|--|--|
![Screenshot 2022-10-11 at 16 46 21](https://user-images.githubusercontent.com/7767575/195138772-6cfb3e5a-33a1-4411-be92-2da2879a4354.png)|![Screenshot 2022-10-11 at 16 46 09](https://user-images.githubusercontent.com/7767575/195138776-98566144-4ac7-4d26-a2be-c46c4a4688ea.png)|

- The hard return overlaps the edge of a note while typing inside it, until you click elsewhere.

|Before|After|
|--|--|
![2022-10-11 17 54 49](https://user-images.githubusercontent.com/49187886/195153401-965583d5-8575-4f5b-ac20-41475ac9a109.gif)|![2022-10-11 17 45 07](https://user-images.githubusercontent.com/49187886/195151383-fd269814-685f-4cd5-9980-5e30a452dc53.gif)|

- Fixes a bug where moving the cursor from inside the note to outside adds another "position" and takes 2 spaces

|Before|After|
|--|--|
![2022-10-11 17 51 38](https://user-images.githubusercontent.com/49187886/195152798-e5451cdb-c068-47c4-9791-36736ee60fdc.gif)|![2022-10-11 17 52 00](https://user-images.githubusercontent.com/49187886/195152911-caa9a7e7-ee92-4675-bddc-81395f19b587.gif)|

## How to test

- In the sandbox, add non-breaking spaces in Firefox. Do they appear as they should?