### PR TITLE
change styling to display cursor on new para line

### DIFF
--- a/src/css/invisibles.css
+++ b/src/css/invisibles.css
@@ -12,7 +12,7 @@
 .invisible:before {
   caret-color: inherit;
   color: gray;
-  display: inline;
+  display: inline-block;
   font-weight: 400;
   font-style: normal;
   line-height: 1em;

--- a/src/css/invisibles.css
+++ b/src/css/invisibles.css
@@ -5,14 +5,14 @@
    * with carets and inline elements when contenteditable
    * is 'false'. See e.g. https://github.com/ProseMirror/prosemirror/issues/1061
    */
-  display: inline-block;
+  display: inline;
   position: relative;
 }
 
 .invisible:before {
   caret-color: inherit;
   color: gray;
-  display: inline-block;
+  display: inline;
   font-weight: 400;
   font-style: normal;
   line-height: 1em;


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Currently the cursor blinks and then upon press return and cursor is on next line, but disappears. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run locally and press return (new paragraph) and check that the cursor is flashing on the new line without having to click in the editor.
## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
|Before|After|
|--|--|
![2022-10-14 13 17 56](https://user-images.githubusercontent.com/49187886/195845244-fab9b57b-43b5-496b-b04b-1bae4178e8e3.gif)|![2022-10-14 13 18 47](https://user-images.githubusercontent.com/49187886/195845298-fa1adbd3-fcd7-4aaa-9dab-aa3700010438.gif)|

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
