### PR TITLE
adds pilcrow to heading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 /dist/
 *.log
 .vs
+.idea/

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -12,6 +12,7 @@ import {
   space,
   nbSpace,
   commands,
+  heading,
 } from "../src/ts";
 
 import "prosemirror-view/style/prosemirror.css";
@@ -31,7 +32,7 @@ const view = new EditorView(document.querySelector("#editor") as Element, {
     ),
     plugins: [
       ...exampleSetup({ schema: mySchema }),
-      createInvisiblesPlugin([hardBreak, paragraph, space, nbSpace]),
+      createInvisiblesPlugin([hardBreak, paragraph, space, nbSpace, heading]),
     ],
   }),
 });

--- a/src/css/invisibles.css
+++ b/src/css/invisibles.css
@@ -61,6 +61,10 @@
   content: "¶";
 }
 
+.invisible--heading:before {
+  content: "¶";
+}
+
 .invisible--nb-space {
   vertical-align: text-bottom;
 }

--- a/src/ts/__tests__/state.spec.ts
+++ b/src/ts/__tests__/state.spec.ts
@@ -8,6 +8,7 @@ import { DecorationSet, EditorView } from "prosemirror-view";
 import hardBreak from "invisibles/hard-break";
 import paragraph from "invisibles/paragraph";
 import nbSpace from "invisibles/nbSpace"
+import heading from "invisibles/heading";
 import { commands, pluginKey } from "state";
 
 const testSchema = new Schema({
@@ -21,7 +22,7 @@ const createEditor = (htmlDoc: string, isActive: boolean) => {
   return new EditorView(contentElement, {
     state: EditorState.create({
       doc: DOMParser.fromSchema(testSchema).parse(contentElement),
-      plugins: [createInvisiblesPlugin([hardBreak, paragraph, space, nbSpace], isActive)],
+      plugins: [createInvisiblesPlugin([hardBreak, paragraph, space, nbSpace, heading], isActive)],
     }),
   });
 };

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -115,6 +115,7 @@ export { default as space } from "invisibles/space";
 export { default as hardBreak } from "invisibles/hard-break";
 export { default as paragraph } from "invisibles/paragraph";
 export { default as nbSpace } from "invisibles/nbSpace";
+export { default as heading } from "invisibles/heading";
 
 export { default as createDeco } from "utils/create-deco";
 export { default as textBetween } from "utils/text-between";

--- a/src/ts/invisibles/heading.ts
+++ b/src/ts/invisibles/heading.ts
@@ -1,0 +1,5 @@
+import { Node } from "prosemirror-model";
+import { createInvisibleDecosForNode } from "./node";
+
+const isHeading = (node: Node): boolean => node.type === node.type.schema.nodes.heading
+export default createInvisibleDecosForNode("heading", (node, pos) => pos + node.nodeSize - 1, isHeading);


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Currently the Pilcrow decoration does not display when we make the text `Heading` / H2
This PR ensures that the Pilcrow clearly displays at the end of a heading
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run locally with `yarn watch` 
Add some text and aply Heading 2 from the menu, checking that a Pilcrow successfully displays at the end of the line
### Images
![2022-10-19 15 56 20](https://user-images.githubusercontent.com/49187886/196727283-1f8d9ab2-0b8d-49ac-b04b-6c7e074877c7.gif)
