### PR TITLE
Use relative imports to fix use in TS projects. Closes #63

### DIFF
--- a/src/ts/__tests__/helpers.ts
+++ b/src/ts/__tests__/helpers.ts
@@ -4,7 +4,7 @@ import {
   nbSpace,
   paragraph,
   hardBreak,
-} from "index";
+} from "../index";
 import { doc, schema } from "prosemirror-test-builder";
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";

--- a/src/ts/__tests__/plugin.spec.ts
+++ b/src/ts/__tests__/plugin.spec.ts
@@ -1,6 +1,6 @@
 import { AllSelection, TextSelection } from "prosemirror-state";
 import { br, doc, p } from "prosemirror-test-builder";
-import { commands } from "state";
+import { commands } from "../state";
 
 import { createEditor } from "./helpers";
 

--- a/src/ts/__tests__/state.spec.ts
+++ b/src/ts/__tests__/state.spec.ts
@@ -1,15 +1,15 @@
 import { createInvisiblesPlugin } from "../";
-import space from "invisibles/space";
+import space from "../invisibles/space";
 import { addListNodes } from "prosemirror-schema-list";
 import { schema } from "prosemirror-schema-basic";
 import { Schema, DOMParser } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 import { DecorationSet, EditorView } from "prosemirror-view";
-import hardBreak from "invisibles/hard-break";
-import paragraph from "invisibles/paragraph";
-import nbSpace from "invisibles/nbSpace"
-import heading from "invisibles/heading";
-import { commands, pluginKey } from "state";
+import hardBreak from "../invisibles/hard-break";
+import paragraph from "../invisibles/paragraph";
+import nbSpace from "../invisibles/nbSpace"
+import heading from "../invisibles/heading";
+import { commands, pluginKey } from "../state";
 import AddDecorationsForInvisible from "../utils/invisible";
 
 const testSchema = new Schema({

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,14 +1,14 @@
 import { Plugin, AllSelection, EditorState } from "prosemirror-state";
 import { DecorationSet, EditorView } from "prosemirror-view";
-import AddDecorationsForInvisible from "utils/invisible";
-import getInsertedRanges, { Range } from "utils/get-inserted-ranges";
+import AddDecorationsForInvisible from "./utils/invisible";
+import getInsertedRanges, { Range } from "./utils/get-inserted-ranges";
 import {
   commands,
   getActionFromTransaction,
   pluginKey,
   PluginState,
   reducer,
-} from "state";
+} from "./state";
 import "../css/invisibles.css";
 
 interface InvisiblesOptions {
@@ -139,17 +139,17 @@ const createInvisiblesPlugin = (
 
 export { createInvisiblesPlugin };
 
-export { createInvisibleDecosForCharacter } from "invisibles/character";
-export { createInvisibleDecosForNode } from "invisibles/node";
+export { createInvisibleDecosForCharacter } from "./invisibles/character";
+export { createInvisibleDecosForNode } from "./invisibles/node";
 
-export { default as space } from "invisibles/space";
-export { default as hardBreak } from "invisibles/hard-break";
-export { default as paragraph } from "invisibles/paragraph";
-export { default as nbSpace } from "invisibles/nbSpace";
-export { default as heading } from "invisibles/heading";
+export { default as space } from "./invisibles/space";
+export { default as hardBreak } from "./invisibles/hard-break";
+export { default as paragraph } from "./invisibles/paragraph";
+export { default as nbSpace } from "./invisibles/nbSpace";
+export { default as heading } from "./invisibles/heading";
 
-export { default as createDeco } from "utils/create-deco";
-export { default as textBetween } from "utils/text-between";
+export { default as createDeco } from "./utils/create-deco";
+export { default as textBetween } from "./utils/text-between";
 
 export { selectActiveState } from "./state";
-export { commands } from "state";
+export { commands } from "./state";

--- a/src/ts/invisibles/character.ts
+++ b/src/ts/invisibles/character.ts
@@ -1,5 +1,5 @@
-import textBetween from "utils/text-between";
-import createDeco from "utils/create-deco";
+import textBetween from "../utils/text-between";
+import createDeco from "../utils/create-deco";
 import AddDecorationsForInvisible, { BuilderTypes } from "../utils/invisible";
 
 export const createInvisibleDecosForCharacter = (

--- a/src/ts/invisibles/node.ts
+++ b/src/ts/invisibles/node.ts
@@ -1,5 +1,5 @@
 import { Node } from "prosemirror-model";
-import createDeco from "utils/create-deco";
+import createDeco from "../utils/create-deco";
 import AddDecorationsForInvisible, { BuilderTypes } from "../utils/invisible";
 
 export const createInvisibleDecosForNode = (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "include": ["src/ts"],
   "compilerOptions": {
-    "baseUrl": "src/ts",
     "lib": ["dom", "esnext"],
     "target": "es5",
     "strict": true,


### PR DESCRIPTION
## What does this change?

The `baseUrl` option in `tsconfig` should not be used in code bases that are meant to be consumed as libraries in other TypeScript-based projects, as the import paths in the emitted `d.ts` files will not be rewritten by the TypeScript compiler, and can not be resolved at build time. Thus the various types re-exported from the main `index.d.ts` module are exported as `any` and not really usable in practice.

## How to test

Set up a separate TS project that imports code from this library, for example:

```ts
import {createInvisibleDecosForCharacter, createInvisiblesPlugin, space} from '@guardian/prosemirror-invisibles';

const shyBuilder = createInvisibleDecosForCharacter('shy', char => char === '\xad');
const invisiblesPlugin = createInvisiblesPlugin([space, shyBuilder]);
```

While the imported symbols were previously imported as `any`, they should now have the proper types.

## How can we measure success?

The library should be (more easily) usable in TS projects.

## Have we considered potential risks?

If anything, this change simplifies the build process, I don't think it can cause unexpected problems.