### PR TITLE
Display soft hyphens

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -7,6 +7,7 @@ import { exampleSetup } from "prosemirror-example-setup";
 import applyDevTools from "prosemirror-dev-tools";
 import {
   createInvisiblesPlugin,
+  softHyphen,
   hardBreak,
   paragraph,
   space,
@@ -32,7 +33,7 @@ const view = new EditorView(document.querySelector("#editor") as Element, {
     ),
     plugins: [
       ...exampleSetup({ schema: mySchema }),
-      createInvisiblesPlugin([hardBreak, paragraph, space, nbSpace, heading], {
+      createInvisiblesPlugin([hardBreak, paragraph, space, nbSpace, heading, softHyphen], {
         displayLineEndSelection: true,
       }),
     ],

--- a/src/css/invisibles.css
+++ b/src/css/invisibles.css
@@ -49,6 +49,10 @@
   background-color: #dcdcdc;
 }
 
+.invisible--soft-hyphen:before {
+  content: "-";
+}
+
 .invisible--space:before {
   content: "·";
 }

--- a/src/ts/__tests__/helpers.ts
+++ b/src/ts/__tests__/helpers.ts
@@ -4,6 +4,7 @@ import {
   nbSpace,
   paragraph,
   hardBreak,
+  softHyphen,
 } from "../index";
 import { doc, schema } from "prosemirror-test-builder";
 import { EditorState } from "prosemirror-state";
@@ -21,7 +22,7 @@ export const createEditor = (
       doc: docNode,
       schema,
       plugins: [
-        createInvisiblesPlugin([hardBreak, paragraph, space, nbSpace], {
+        createInvisiblesPlugin([hardBreak, paragraph, space, nbSpace, softHyphen], {
           shouldShowInvisibles: shouldShowInvisibles,
           displayLineEndSelection,
         }),

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -144,6 +144,7 @@ export { createInvisibleDecosForNode } from "./invisibles/node";
 
 export { default as space } from "./invisibles/space";
 export { default as hardBreak } from "./invisibles/hard-break";
+export { default as softHyphen } from "./invisibles/soft-hyphen";
 export { default as paragraph } from "./invisibles/paragraph";
 export { default as nbSpace } from "./invisibles/nbSpace";
 export { default as heading } from "./invisibles/heading";

--- a/src/ts/invisibles/soft-hyphen.ts
+++ b/src/ts/invisibles/soft-hyphen.ts
@@ -1,0 +1,4 @@
+import { createInvisibleDecosForCharacter } from "./character";
+
+const isSoftHyphen = (char: string) => char === "\u00ad";
+export default createInvisibleDecosForCharacter("soft-hyphen", isSoftHyphen);


### PR DESCRIPTION
## What does this change?

Adds an additional invisible for soft hyphens (U+00AD) - https://en.wikipedia.org/wiki/Soft_hyphen

## How to test

Run demo app, copy + paste text including soft hyphen. See soft hyphen displayed on top of existing text.  We have decided not to create additional space for this invisible.