### PR TITLE
fix: Skip SBT instead of Node in Snyk workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,6 +13,6 @@ jobs:
     with:
       DEBUG: true
       ORG: guardian
-      SKIP_NODE: true
+      SKIP_SBT: true
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Modifies the Snyk workflow to not skip Node dependencies, as this is a Node project and [Snyk is reporting 0 dependencies existing for this repo](https://app.snyk.io/org/guardian/project/7d110dca-17f7-4d7f-b539-909e2ba4de5e) as a result, which means that vulnerabilities will not be scanned. Instead, we skip SBT as there is no Scala in this repo. This came to our attention during the DevX Security team's recent work on Repocop to alert on vulnerabilities.

## How to test

## How can we measure success?

Once merged, the Snyk dashboard should show this repo's dependencies and report on any vulnerabilities.