### PR TITLE
Public npm package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.changeset/serious-dryers-leave.md
+++ b/.changeset/serious-dryers-leave.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-invisibles": patch
+---
+
+Change package access to public


### PR DESCRIPTION
The default configuration for the changesets public sets the package access to "restricted" which isn't really what we want, since this package has already been published publicly. This PR changes the access to "public".